### PR TITLE
seq2

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -27,6 +27,7 @@ export(rbind_common)
 export(catch_asNumericIfPossible)
 export(do_call_rbind_withName)
 export(readMultisep)
+export(seq2)
 
 # eatRep usage
 export(existsBackgroundVariables)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # eatTools 0.7.4.9000
 
+* added `seq2()` for sequence generation
 * adapt `halveString()` for patterns with more than 1 character
 * add messages to `mergeAttr()` if combinations of merge variables from one data set do not occur in the other data set
 * `makeDataFrame()` gives warning/errors if data.frame has less rows than expected at the least.

--- a/R/seq2.R
+++ b/R/seq2.R
@@ -1,0 +1,9 @@
+
+seq2 <- function(from, to) {
+  if (from > to) {
+    integer()
+  }
+  else {
+    seq.int(from, to)
+  }
+}

--- a/man/seq2.Rd
+++ b/man/seq2.Rd
@@ -1,0 +1,24 @@
+\name{seq2}
+\alias{seq2}
+\title{
+Sequence generation
+}
+\description{
+Creates a sequence of integers. Modified version of \code{seq} returning an empty vector if the starting point is larger than the end point.
+Originally provided by \code{rlang::seq2()}.
+}
+\usage{
+seq2(from, to)
+}
+\arguments{
+
+  \item{from}{The starting value of the sequence. Of length 1.}
+  \item{to}{The end value of the sequence. Of length 1.}
+
+}
+\value{
+A numerical sequence
+}
+\examples{
+seq2(from = 1, to = 5)
+}

--- a/tests/testthat/test_seq2.R
+++ b/tests/testthat/test_seq2.R
@@ -1,0 +1,6 @@
+
+test_that("seq2", {
+  expect_identical(seq2(1, 5), 1:5)
+  expect_identical(seq2(-3, 0), -3:0)
+  expect_identical(seq2(1, 0), integer())
+})


### PR DESCRIPTION
This adds `seq2()`, inspired by `rlang`. Comes in handy if sequences are generated for loops and should be an empty vector if, e.g. `from = 1` and `to = 0`.