### PR TITLE
removed language dependent tests

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # eatTools 0.7.4.9000
 
+* internal fixes to tests (removed language dependency)
 * new function `makeTria()` for internal use in `eatTools` and `eatModel` reshapes covariance/correlation matrices into triangular shape
 * added `seq2()` for sequence generation
 * adapt `halveString()` for patterns with more than 1 character

--- a/R/addLeadingZeros.R
+++ b/R/addLeadingZeros.R
@@ -1,7 +1,13 @@
 
 addLeadingZerosToCharInt <- function(dat) {
-  stopifnot(is.data.frame(dat))
-  stopifnot(all(sapply(dat, is.character )))
+  if(!is.data.frame(dat)) {
+    stop("Argument dat must be a data.frame.")
+  }
+  is_character <- sapply(dat, is.character )
+  if(!all(is_character)) {
+    stop("All columns in dat need to be of class character.")
+  }
+
   pattern <- "(^(-|\\+)?\\d+$)|(^(-|\\+)?(\\d*)e(-|\\+)?(\\d+)$)"
   elToCorrect <- lapply(dat,function(hh) grepl(pattern, hh)|is.na(hh))
   isna <- lapply(dat,function(hh) is.na(hh))

--- a/R/do_call_rbind_withName.R
+++ b/R/do_call_rbind_withName.R
@@ -1,8 +1,16 @@
 do_call_rbind_withName <- function (df_list, name = names(df_list), colName){
-  if(!is.list(df_list) || any(sapply(df_list, function(x) !is.data.frame(x)))) stop("'df_list' must be a list of data.frames.")
-  if(!is.character(name) || length(df_list) != length(name)) stop("'name' must be a character vector of identical length as 'df_list'.")
-  if(!is.character(colName) || length(colName) != 1) stop("'colName' must be a character vector of length 1.")
-  if(colName %in% names(df_list[[1]])) stop("'colName' is already in use in the elements of 'df_list'.")
+  if(!is.list(df_list) || any(sapply(df_list, function(x) !is.data.frame(x)))) {
+    stop("'df_list' must be a list of data.frames.")
+  }
+  if(!is.character(name) || length(df_list) != length(name)) {
+    stop("'name' must be a character vector of identical length as 'df_list'.")
+  }
+  if(!is.character(colName) || length(colName) != 1) {
+    stop("'colName' must be a character vector of length 1.")
+  }
+  if(colName %in% names(df_list[[1]])) {
+    stop("'colName' is already in use in the elements of 'df_list'.")
+  }
 
   df_list2 <- Map(function(df, name) {
     if (is.null(df))

--- a/R/insert.col.r
+++ b/R/insert.col.r
@@ -1,8 +1,6 @@
 
 insert.col <- function (dat, toinsert, after) {
-  if(!is.data.frame(dat)) {
-    stop("Argument dat must be a data.frame.")
-  }
+  dat <- makeDataFrame(dat)
 
   if ( is.character ( toinsert ) ) toinsert <- which ( colnames ( dat ) %in% toinsert )
   if ( is.character ( after ) ) after <- which ( colnames ( dat ) %in% after )

--- a/R/insert.col.r
+++ b/R/insert.col.r
@@ -1,7 +1,9 @@
 
-insert.col <- function ( dat , toinsert , after ) {
+insert.col <- function (dat, toinsert, after) {
+  if(!is.data.frame(dat)) {
+    stop("Argument dat must be a data.frame.")
+  }
 
-  stopifnot ( is.data.frame ( dat ) )
   if ( is.character ( toinsert ) ) toinsert <- which ( colnames ( dat ) %in% toinsert )
   if ( is.character ( after ) ) after <- which ( colnames ( dat ) %in% after )
   stopifnot ( is.numeric ( toinsert ) )

--- a/man/insert.col.rd
+++ b/man/insert.col.rd
@@ -1,9 +1,9 @@
 \name{insert.col}
 \alias{insert.col}
-\title{Insert Columns into a \column{data.frame} at a Specific Position
+\title{Insert Columns into a \code{data.frame} at a Specific Position
 }
 \description{
-  Insert columns into a \column{data.frame} at a specific position. Transforms \code{tibble} or \code{data.table} to \code{data.frame}.
+  Insert columns into a \code{data.frame} at a specific position. Transforms \code{tibble} or \code{data.table} to \code{data.frame}.
 }
 \usage{
   insert.col(dat, toinsert, after)

--- a/man/insert.col.rd
+++ b/man/insert.col.rd
@@ -1,9 +1,9 @@
 \name{insert.col}
 \alias{insert.col}
-\title{Insert Columns into a Data Frame in a Specific Position
+\title{Insert Columns into a \column{data.frame} at a Specific Position
 }
 \description{
-  Insert columns into a data frame in specific position
+  Insert columns into a \column{data.frame} at a specific position. Transforms \code{tibble} or \code{data.table} to \code{data.frame}.
 }
 \usage{
   insert.col(dat, toinsert, after)

--- a/tests/testthat/test_addLeadingZeros.R
+++ b/tests/testthat/test_addLeadingZeros.R
@@ -9,8 +9,10 @@ dat <- set.col.type(dat)
 addLeadingZerosToCharInt(dat)
 
 test_that("Errors", {
-  expect_error(addLeadingZerosToCharInt(1), "is.data.frame(dat) is not TRUE", fixed = TRUE)
-  expect_error(addLeadingZerosToCharInt(mtcars), "all(sapply(dat, is.character)) is not TRUE", fixed = TRUE)
+  expect_error(addLeadingZerosToCharInt(1),
+               "Argument dat must be a data.frame.")
+  expect_error(addLeadingZerosToCharInt(mtcars),
+               "All columns in dat need to be of class character.")
 })
 
 test_that("Factor vector drop levels", {

--- a/tests/testthat/test_do_call_rbind_withName.R
+++ b/tests/testthat/test_do_call_rbind_withName.R
@@ -46,8 +46,5 @@ test_that("errors", {
                "'df_list' must be a list of data.frames.")
 
   df_list[[2]] <- df_list[[2]][, 1, drop = FALSE]
-
-  expect_error(do_call_rbind_withName(df_list, colName = "variable"),
-               "numbers of columns of arguments do not match")
-
+  expect_error(do_call_rbind_withName(df_list, colName = "variable"))
 })

--- a/tests/testthat/test_insert.col.R
+++ b/tests/testthat/test_insert.col.R
@@ -2,7 +2,7 @@
 
 test_that("Errors", {
   expect_error(insert.col(1),
-               "Argument dat must be a data.frame.")
+               "'dat' is neither a 'data.frame', 'tibble' or 'data.table' object.")
 })
 
 ###
@@ -12,5 +12,15 @@ test_that("Insert one column in data.frame by name", {
 
   out <- insert.col(mtcars, toinsert = "mpg", after = "cyl")
   expect_equal(out, mtcars[, c(2, 1, 3:11)])
+})
+
+###
+test_that("Insert one column in data.table by name", {
+  mtcars_table <- as.data.table(mtcars)
+  suppressMessages(out <- insert.col(mtcars_table, toinsert = "mpg", after = "carb"))
+
+  mtcars2 <- mtcars
+  rownames(mtcars2) <- NULL
+  expect_equal(out, mtcars2[, c(2:11, 1)])
 })
 

--- a/tests/testthat/test_insert.col.R
+++ b/tests/testthat/test_insert.col.R
@@ -1,7 +1,8 @@
 
 
 test_that("Errors", {
-  expect_error(insert.col(1), "is.data.frame(dat) is not TRUE", fixed = TRUE)
+  expect_error(insert.col(1),
+               "Argument dat must be a data.frame.")
 })
 
 ###


### PR DESCRIPTION
Mostly due to the usage of `stopifnot()` a number of tests in `eatTools` were language dependent and raised errors on machines with German OSs. This PR fixes this issue as reported in #7 .