### PR TITLE
assertions for whereAre

### DIFF
--- a/R/whereAre.r
+++ b/R/whereAre.r
@@ -1,4 +1,7 @@
 whereAre <- function(a,b,verbose=TRUE) {
+            checkmate::assert_scalar(a)
+            checkmate::assert_vector(b)
+            checkmate::assert_logical(verbose)
             b <- data.frame(1:length(b),b,stringsAsFactors=FALSE)               ### zusaetzliche Syntaxbefehle sind notwendig, damit die Funktion mit missing values umgehen kann.
             if(sum(which(is.na(a)))>0)     {if(verbose) { cat("a contains missing values. \n")}}
             if(sum(which(is.na(b[,2])))>0) {if(verbose) { cat("b contains missing values. \n")}}


### PR DESCRIPTION
I added a simple assert_vector for `b`, but in the documentation it says, it wants either character or numeric input. 
I haven't found a simple check for that within checkmate though, to check for 2 specific types at the same time. 
should I just leave it at that, or try something like this?

b <- c("ds", 1:3)
c <- 1:5

assert_multi_class(c, c("character", "numeric")) # problem: typeof(c) is "integer"

if(!(test_character(c) || test_numeric(c))){
  stop("error message tbd")
}