### PR TITLE
assertion for wtdTable

### DIFF
--- a/R/wtdTable.r
+++ b/R/wtdTable.r
@@ -2,6 +2,7 @@
 utils::globalVariables(c(".", "wgt", "variable"))
 
 wtdTable <- function ( x, weights, na.rm = FALSE) {
+            checkmate::assert_vector(x)
             checkmate::assert_numeric(weights, lower = 0)
             frm   <- data.frame ( variable=x, wgt=weights, stringsAsFactors=FALSE)
             if ( na.rm == TRUE ) {frm <- na.omit(frm)}


### PR DESCRIPTION
here I had similar problems like in #25. 
I cannot easily check for several types via checkmate alone, just something like this:

if(!(test_character(x) || test_factor(x))){
  stop("'x' must be either of type 'character' or 'factor' or 'category'.")
}
