### PR TITLE
bugfix in gsubAll()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,3 +30,4 @@ Suggests:
     testthat,
     covr
 NeedsCompilation: no
+RoxygenNote: 7.3.1

--- a/R/remove_funs.R
+++ b/R/remove_funs.R
@@ -22,12 +22,22 @@ crop <- function ( x , char = " " ) {
 
 ### gsub for more than one pattern
 gsubAll <- function(string, old, new) {
-  stopifnot ( is.character(string), is.character(old), is.character(new), length(old) == length(new))
+  checkmate::assert_character(string)
+  lapply(list(old, new), FUN = checkmate::assert_character,unique=TRUE, any.missing = FALSE, min.len = 2)
+  stopifnot ( length(old) == length(new))
+  stopifnot (length(intersect(old, new))==0)                                    ### in einem Zwischenschritt unique IDs mit gleich vielen characters erzeugen
+  inter <- stringi::stri_rand_strings(n=length(old), length=12, pattern="[A-Za-z0-9]")
+  stopifnot(length(unique(inter)) == length(inter))
+  ind <- sort(nchar(old), decreasing = TRUE, index.return=TRUE)                 ### sortieren nach nchar(), wenn kuerzere strings in laengeren enthalten
+  old <- old[ind[["ix"]]]
+  new <- new[ind[["ix"]]]
   for(i in seq_along(old)) {
-    string <- gsub(old[i], new[i], string)
+    string <- gsub(old[i], inter[i], string)
   }
-  return(string)
-}
+  for(i in seq_along(old)) {
+    string <- gsub(inter[i], new[i], string)
+  }
+  return(string)}
 
 
 ### splits the string only on the first or the last occurrence of the separator

--- a/tests/testthat/test_remove_funs.R
+++ b/tests/testthat/test_remove_funs.R
@@ -65,4 +65,9 @@ test_that("halveString5", {
   expect_equal(d1[,"a"], c("BB/DHW", "BB/GL", "BB/GM" ))
 })
 
-
+# problem: nested pattern
+test_that("gsubAll", {
+  string <- c("I1: erstes Item", "I12: zwoelftes Item", "I11: elftes Item")
+  string1<- gsubAll ( string, old = c("I11", "I12", "I1"), new = c("Item I11", "Item I12", "Item I1"))
+  expect_equal(string1, c("Item I1: erstes Item", "Item I12: zwoelftes Item", "Item I11: elftes Item"))
+})


### PR DESCRIPTION
nested string replacement fixed:
I've added some tests ... running the script lines from the test with the old gsubAll() function demonstrates the error. 